### PR TITLE
Fix for phpunit "no assertion" warning, making tests more robust

### DIFF
--- a/tests/ParkourTest.php
+++ b/tests/ParkourTest.php
@@ -28,7 +28,7 @@ class ParkourTest extends TestCase {
 	public function closure(array $values) {
 		$Mock = $this->getMock('stdClass', ['method']);
 
-		$Mocker = $Mock->expects($this->any());
+		$Mocker = $Mock->expects($this->exactly(count($values)));
 		$Mocker->method('method');
 		$Mocker->will($this->returnValueMap($values));
 
@@ -190,6 +190,11 @@ class ParkourTest extends TestCase {
 			$expected,
 			Parkour::filter($data, $closure)
 		);
+
+		$closure = $this->closure([
+			[1, 'a', false],
+			[2, 'b', true]
+		]);
 
 		$expected = [2];
 


### PR DESCRIPTION
Phpunit complains about testInvoke, which does not perform any assertions.
Indeed testInvoke only checks, thanks to the 'closure' function, that when
the closure is called, the expected parameters are passed. It does not check
that the closure is called the expected number of times.

This commit changes the closure function so that it checks the number of
times it is called, removing the warning and making the whole test more robust
