### PR TITLE
Ungreedy "some" and "every"

### DIFF
--- a/lib/Parkour.php
+++ b/lib/Parkour.php
@@ -119,7 +119,7 @@ class Parkour {
 	 *	@return boolean Result.
 	 */
 	public static function some(array $data, callable $test) {
-		return self::mapReduce($data, $test, new Disjunct(), false);
+		return self::firstOk($data, $test) !== false;
 	}
 
 

--- a/lib/Parkour.php
+++ b/lib/Parkour.php
@@ -6,8 +6,6 @@
  */
 namespace Parkour;
 
-use Parkour\Functor\Conjunct;
-use Parkour\Functor\Disjunct;
 use Parkour\Functor\Identity;
 use Parkour\Functor\AlwaysTrue;
 

--- a/lib/Parkour.php
+++ b/lib/Parkour.php
@@ -105,7 +105,7 @@ class Parkour {
 	 *	@return boolean Result.
 	 */
 	public static function every(array $data, callable $test) {
-		return self::mapReduce($data, $test, new Conjunct(), true);
+		return self::firstNotOk($data, $test) === false;
 	}
 
 

--- a/tests/ParkourTest.php
+++ b/tests/ParkourTest.php
@@ -189,7 +189,7 @@ class ParkourTest extends TestCase {
 		$closure = $this->closure([
 			[1, 0, true],
 			[2, 1, false]
-		]);
+		],1);
 
 		$this->assertTrue(Parkour::some($data, $closure));
 	}

--- a/tests/ParkourTest.php
+++ b/tests/ParkourTest.php
@@ -159,7 +159,7 @@ class ParkourTest extends TestCase {
 		$closure = $this->closure([
 			[1, 0, false],
 			[2, 1, true]
-		]);
+		],1);
 
 		$this->assertFalse(Parkour::every($data, $closure));
 


### PR DESCRIPTION
Parkour::some and Parkour::every both use Parkour::mapReduce, which loop on the entire array.

This branch replaces mapReduce with firstOk and firstNotOk, which might return before iterating on the whole array.