### PR TITLE
Update required php version to 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"test": "vendor/phpunit/phpunit/phpunit"
 	},
 	"require": {
-		"php": ">=5.5.0"
+		"php": ">=5.6.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "4.3.*"


### PR DESCRIPTION
Current `Traverse::filter` implementation breaks on 5.5.
Since PHP 5.5 isn't actively supported anymore, don't bother to support it.
